### PR TITLE
Enable S3 public access blocks in CloudFormation

### DIFF
--- a/comprehend-semi-structured-documents-annotation-template.yml
+++ b/comprehend-semi-structured-documents-annotation-template.yml
@@ -53,6 +53,11 @@ Resources:
           - AllowedHeaders: []
             AllowedMethods: [GET]
             AllowedOrigins: ['*']
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   SemiStructuredDocumentsS3BucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
**Issue #, if available:** #20

**Description of changes:**

I agree with the linked issue - can't see any reason the `SemiStructuredDocumentsS3Bucket` created by this CloudFormation needs to be accessed outside AWS? So as best practice the [S3 public access blocks](https://docs.aws.amazon.com/AmazonS3/latest/userguide/configuring-block-public-access-bucket.html) should be enabled on it.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
